### PR TITLE
Chapter 3: Missing variable definition in __rmul__

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -429,6 +429,7 @@ It turns out there's a really fun technique called binary expansion. If bits is 
 class Point:
     ...
     def __rmul__(self, coefficient):
+        coef = coefficient
         current = self  # <1>
         result = self.__class__(None, None, self.a, self.b)  # <2>
         while coef:


### PR DESCRIPTION
In \_\_rmul\_\_ of the class Point, the loop variable „coef“ is not defined in the code that is shown in the chapter.