### PR TITLE
Fix typos in ch01.asciidoc & ch02.asciidoc

### DIFF
--- a/ch01.asciidoc
+++ b/ch01.asciidoc
@@ -563,4 +563,4 @@ Thankfully, we can do even better. We already know how to force a number into th
 
 === Conclusion
 
-In thes chapter we learned about Finite Fields and how to implement it in Python. We'll be utilizing thes in Chapter 3 for Elliptic Curve Cryptography. We turn next to the other mathematical component that we need and that's Elliptic Curves.
+In this chapter we learned about Finite Fields and how to implement it in Python. We'll be utilizing these in Chapter 3 for Elliptic Curve Cryptography. We turn next to the other mathematical component that we need and that's Elliptic Curves.

--- a/ch02.asciidoc
+++ b/ch02.asciidoc
@@ -68,7 +68,7 @@ image::elliptic3.png[secp256k1 Curve]
 
 === Coding Elliptic Curves in Python
 
-For a variety of reasons which will be clear later, we are not interested in the curve itself, but specific points on the curve. For example, in the curve y^2^=x^3^+5x+7, we are interested in the coordinate (-1,1). We are thus going to define the class `Point` to be the actual point on a specific curve. The curve has a specifc form, y^2^=x^3^+ax+b so we can define the curve with just the two numbers *a* and *b*.
+For a variety of reasons which will be clear later, we are not interested in the curve itself, but specific points on the curve. For example, in the curve y^2^=x^3^+5x+7, we are interested in the coordinate (-1,1). We are thus going to define the class `Point` to be the actual point on a specific curve. The curve has a specific form, y^2^=x^3^+ax+b so we can define the curve with just the two numbers *a* and *b*.
 
 [source,python]
 ----
@@ -87,7 +87,7 @@ class Point:
 
 ----
 <1> We check here that the point is actually on the curve.
-<2> Points are equal iff they are on the same curve and have the same coordinates
+<2> Points are equal if they are on the same curve and have the same coordinates.
 
 This allows us to do something like this:
 
@@ -314,7 +314,7 @@ We can use this to derive the formula for x~3~:
 
 x~3~=s^2^-x~1~-x~2~
 
-We can plug this in to the formula for the line above:
+We can plug this into the formula for the line above:
 
 y=s(x-x~1~)+y~1~
 


### PR DESCRIPTION
Fixes were limited exclusively to spelling errors (and one grammatical error). The git diff should highlight the exact words that were edited.