### PR TITLE
Chapter 4: Wrong decimal value in Big-Endian example

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -32,7 +32,7 @@ The motivation for Big and Little Endian encodings is storing a number on disk. 
 
 Computers can sometimes be more efficient using the opposite order or Little-Endian. That is, starting with the Little End first.
 
-Since Computers work in bytes, which have 8 bits, we have to think in base-256. This means that a number like 500 looks like this in Big-Endian `01f4`. That is, 500 = 1*256 + 246 (`f4` in hexadecimal). The same number looks like this in Little-Endian `f401`.
+Since Computers work in bytes, which have 8 bits, we have to think in base-256. This means that a number like 500 looks like this in Big-Endian `01f4`. That is, 500 = 1*256 + 244 (`f4` in hexadecimal). The same number looks like this in Little-Endian `f401`.
 
 Unfortunately, some stuff in Bitcoin (like the SEC format x and y coordinates) are in Big-Endian. Other stuff in Bitcoin (like the transaction version number) are in Little-Endian. This book will let you know which ones are Big vs Little Endian.
 ====


### PR DESCRIPTION
There is a small numerical error in the following calculation:

> This means that a number like 500 looks like this in Big-Endian 01f4. That is, 500 = 1*256 + 246 (f4 in hexadecimal).

The last summand should be 244 instead of 246.