### PR TITLE
Chapter 7: Bug in fee() method

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -46,7 +46,7 @@ class Tx:
         '''Returns the fee of this transaction in satoshi'''
         input_sum, output_sum = 0, 0
         for tx_in in self.tx_ins:
-            input_sum += tx_in.amount(testnet=testnet)
+            input_sum += tx_in.value(testnet=testnet)
         for tx_out in self.tx_outs:
             output_sum += tx_out.amount
         return input_sum - output_sum


### PR DESCRIPTION
In fee() the nonexistent method amount() is called on TxIn instances.