### PR TITLE
Fixed images path

### DIFF
--- a/ch01.asciidoc
+++ b/ch01.asciidoc
@@ -363,7 +363,7 @@ That is, the result of field multiplication is always in the set {0,1,...p-1}.
 
 Exponentiation is simply multiplying a number many times.
 
-7^3^=7⋅~f~7⋅~f~7=343
+7^3^=7⋅7⋅7=343
 
 In a Finite Field, we can do exponentiation using modulo arithmetic.
 

--- a/ch01.asciidoc
+++ b/ch01.asciidoc
@@ -150,7 +150,7 @@ Modulo arithmetic is something you probably learned when you first learned divis
 Remember problems like Figure 1-1?
 
 .Long Division Example 1
-image::longdivision.png[Long Division Example 1]
+image::images/longdivision.png[Long Division Example 1]
 
 Whenever the division wasn't even, there was something called the "remainder" which is the leftover from the actual division.
 We define modulo in the same way.
@@ -161,7 +161,7 @@ We use the operator *%* for "modulo".
 Figure 1-2 shows another example.
 
 .Long Division Example 2
-image::longdivision-2.png[Long Division Example 2]
+image::images/longdivision-2.png[Long Division Example 2]
 
 Formally speaking, the modulo operation is the remainder after division of one number by another.
 Let's look at another example with larger numbers:
@@ -177,7 +177,7 @@ What hour will it be 47 hours from now?
 The answer is 2 o'clock because (3 + 47) % 12 = 2 (see Figure 1-3)
 
 .Clock going forward 47 hours
-image::clock.jpg[Clock]
+image::images/clock.jpg[Clock]
 
 We can also see this as "wrapping around" in the sense that you go past zero every time we move ahead 12 hours.
 

--- a/ch02.asciidoc
+++ b/ch02.asciidoc
@@ -27,44 +27,44 @@ You may even remember that *m* here has the name _slope_ and *b*, _y-intercept_.
 You can also graph linear equations like Figure 2-1:
 
 .Linear Equation
-image::linear.png[Linear Equation]
+image::images/linear.png[Linear Equation]
 
 Similarly, you're probably familiar with the quadratic equation and its graph (Figure 2-2):
 
 y = ax^2^+bx+c
 
 .Quadratic Equation
-image::quadratic.png[Quadratic Equation]
+image::images/quadratic.png[Quadratic Equation]
 
 And sometime around Algebra, you did even higher orders of `x`, something called the cubic equation and its graph (Figure 2-3):
 
 y = ax^3^+bx^2^+cx+d
 
 .Cubic Equation
-image::cubic.png[Cubic Equation]
+image::images/cubic.png[Cubic Equation]
 
 An Elliptic Curve isn't all that different.
 The only real difference between the Elliptic Curve and the cubic curve above is the *y^2^* term on the left side.
 This has the effect of making the graph symmetric over the x-axis, shown in Figure 2-4:
 
 .Continuous Elliptic Curve
-image::elliptic2.png[Elliptic Curve Equation]
+image::images/elliptic2.png[Elliptic Curve Equation]
 
 The Elliptic Curve is also less steep than the cubic curve.
 Again, this is because of the *y^2^* term on the left side.
 At times, the curve may even be disjoint like Figure 2-5:
 
 .Disjoint Elliptic Curve
-image::elliptic1.png[Elliptic Curve Equation]
+image::images/elliptic1.png[Elliptic Curve Equation]
 
 If it helps, an Elliptic Curve can be though of as taking a cubic equation graph (Figure 2-6), taking only the part above the x-axis, flattening it out (Figure 2-7) and then mirroring the top half on the bottom half of the x-axis (Figure 2-8).
 
 .Step 1: A Cubic Equation
-image::process1.png[Start]
+image::images/process1.png[Start]
 .Step 2: Stretched Cubic Equation
-image::process2.png[Stretch]
+image::images/process2.png[Stretch]
 .Step 3: Reflected over the X-Axis
-image::process3.png[Symmetric]
+image::images/process3.png[Symmetric]
 
 Specifically, the Elliptic Curve used in Bitcoin is called secp256k1 and it uses this particular equation:
 
@@ -74,7 +74,7 @@ The canonical form is y^2^=x^3^+ax+b so the curve is defined by the constants `a
 The curve looks like Figure 2-9:
 
 .secp256k1 Curve
-image::elliptic3.png[secp256k1 Curve]
+image::images/elliptic3.png[secp256k1 Curve]
 
 === Coding Elliptic Curves in Python
 
@@ -115,16 +115,16 @@ The way we define Point Addition is as follows.
 It turns out that for every Elliptic Curve, a line will intersect it at either 1 point (Figure 2-10) or 3 points (Figure 2-11), except for a couple of special cases.
 
 .Line intersects at only 1 point
-image::intersect1.png[Line intersecting at 1 point]
+image::images/intersect1.png[Line intersecting at 1 point]
 .Line intersects at 3 points
-image::intersect3.png[Line intersecting at 3 points]
+image::images/intersect3.png[Line intersecting at 3 points]
 
 The two exceptions are when a line is _tangent_ to the curve (Figure 2-13) and when a line is exactly vertical (Figure 2-12).
 
 .Line intersects at 2 points because it's vertical
-image::intersect2-1.png[Vertical Line]
+image::images/intersect2-1.png[Vertical Line]
 .Line intersects at 2 points because it's tangent to the curve
-image::intersect2-2.png[Tangent Line]
+image::images/intersect2-2.png[Tangent Line]
 
 We will come back to these two cases later.
 
@@ -143,7 +143,7 @@ For any two points P~1~=(x~1~,y~1~) and P~2~=(x~2~,y~2~), we get P~1~+P~2~ by:
 Visually, it looks like Figure 2-14:
 
 .Point Addition
-image::pointaddition.png[Point Addition]
+image::images/pointaddition.png[Point Addition]
 
 We first draw a line through the two points we're adding (A and B).
 The third intersection point is C.
@@ -179,7 +179,7 @@ A + (-A) = I
 Visually, these are points opposite the x-axis on the curve (see Figure 2-15).
 
 .Vertical Line Intersection
-image::intersect2-1.png[Vertical Line]
+image::images/intersect2-1.png[Vertical Line]
 
 This is why we call this point the point at infinity.
 We have one extra point in the Elliptic Curve which makes the vertical line intersect the curve a third time.
@@ -191,9 +191,9 @@ Associativity means that (A+B) + C = A + (B+C).
 This isn't obvious and is the reason for flipping over the x-axis.
 
 .(A+B)+C
-image::associativity1.png[Case 1]
+image::images/associativity1.png[Case 1]
 .A+(B+C)
-image::associativity2.png[Case 2]
+image::images/associativity2.png[Case 2]
 
 You can see that in both Figure 2-16 and Figure 2-17, the final point is the same.
 While this doesn't prove the associativity of point addition, the visual should at least give you the intuition that this is true.
@@ -349,7 +349,7 @@ Visually, we have to calculate the line that's *tangent* to the curve at P~1~ an
 The situation looks like this as we saw before (see Figure 2-18):
 
 .Line that's tangent to the curve
-image::intersect2-2.png[Tangent Line]
+image::images/intersect2-2.png[Tangent Line]
 
 Once again, we'll find the slope of the tangent point.
 
@@ -404,7 +404,7 @@ include::code-ch02/answers.py[tag=exercise7,indent=0]
 There is one more exception and this involves the case where the tangent line is vertical (Figure 2-19):
 
 .Vertical and Tangent to the curve
-image::tangentvertical.png[Tangent Vertical]
+image::images/tangentvertical.png[Tangent Vertical]
 
 This can only happen if P~1~=P~2~ and the y-coordinate is 0, in which case the slope calculation will end up with a 0 in the denominator.
 

--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -28,7 +28,7 @@ Real numbers are easy to plot and we can see the a graph over reals visually.
 For example, y^2^=x^3^+7 can be plotted like Figure 3-1:
 
 .secp256k1 over real numbers
-image::elliptic3.png[secp256k1 Curve]
+image::images/elliptic3.png[secp256k1 Curve]
 
 It turns out we can use the point addition equations over any field, including the Finite Fields we learned in <<chapter_finite_fields>>.
 The only difference is that we have to use the addition/subtraction/multiplication/division as defined in <<chapter_finite_fields>>, not the "normal" versions that the real numbers use.
@@ -47,7 +47,7 @@ We've verified that the point is on the curve using Finite Field math.
 Because we're evaluating the equation over a Finite Field, the plot of the equation looks vastly different (Figure 3-2):
 
 .Elliptic Curve over a Finite Field
-image::finitefieldellipticcurve.png[Elliptic Curve over a Finite Field]
+image::images/finitefieldellipticcurve.png[Elliptic Curve over a Finite Field]
 
 As you can see, it's very much a scattershot of points and there's no smooth curve here.
 This is not surprising since the points are discrete.
@@ -113,7 +113,7 @@ y=mx+b
 It turns out that a "line" in a Finite Field is not quite what you'd expect (Figure 3-3):
 
 .Line over a Finite Field
-image::linefinitefield.png[Line over a Finite Field]
+image::images/linefinitefield.png[Line over a Finite Field]
 
 The equation nevertheless works and we can calculate what `y` should be for a given `x`.
 
@@ -171,7 +171,7 @@ We can do this because we have defined point addition and point addition is asso
 One property of scalar multiplication is that it's really hard to predict without calculating (see Figure 3-4):
 
 .Scalar Multiplication Results for y^2^=x^3^+7 over F~223~ for point (170,142)
-image::scatterplot.png[Scalar Multiplication Results]
+image::images/scatterplot.png[Scalar Multiplication Results]
 
 Each point is labeled by how many times we've added the point.
 You can see that this is a complete scattershot.
@@ -269,7 +269,7 @@ So:
 We call 0 the point at infinity because visually, it's the point that exists to help the math work out (Figure 3-5):
 
 .Vertical Line "intersects" a third time at the point at infinity
-image::intersect2-1.png[Vertical Line]
+image::images/intersect2-1.png[Vertical Line]
 
 ==== Closure
 
@@ -297,7 +297,7 @@ So we know that this element is in the group, proving closure.
 Visually, invertibility is easy to see (Figure 3-6):
 
 .Each point is invertible by taking the reflection over the x-axis
-image::intersect2-1.png[Vertical Line]
+image::images/intersect2-1.png[Vertical Line]
 
 Mathematically, we know that if aG is in the group, (n-a)G is also in the group.
 You can add them together to get aG+(n-a)G=(a+n-a)G=nG=0.
@@ -307,7 +307,7 @@ You can add them together to get aG+(n-a)G=(a+n-a)G=nG=0.
 We know from Point Addition that A+B=B+A (Figure 3-7):
 
 .The Line through the points doesn't change
-image::pointaddition.png[Point Addition]
+image::images/pointaddition.png[Point Addition]
 
 This means that aG+bG=bG+aG, which proves commutativity.
 
@@ -316,9 +316,9 @@ This means that aG+bG=bG+aG, which proves commutativity.
 We know from Point Addition that A+(B+C)=(A+B)+C (see Figure 3-8 and 3-9)
 
 .(A+B)+C
-image::associativity1.png[Case 1]
+image::images/associativity1.png[Case 1]
 .A+(B+C)
-image::associativity2.png[Case 2]
+image::images/associativity2.png[Case 2]
 
 Thus, aG+(bG+cG)=(aG+bG)+cG proving associativity.
 

--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -28,7 +28,7 @@ Here is how the uncompressed SEC format for a given point P=(x,y) is generated:
 The uncompressed SEC format is in Figure 4-1:
 
 .Uncompressed SEC Format
-image::sec1.png[Uncompressed SEC Format]
+image::images/sec1.png[Uncompressed SEC Format]
 
 [WARNING]
 .Big and Little Endian
@@ -77,7 +77,7 @@ include::code-ch04/answers.py[tag=exercise1,indent=0]
 Recall that for any x-coordinate, there are at most two y-coordinates due to the y^2^ term in the elliptic curve equation (Figure 4-2):
 
 .The two possible values for y are where this vertical line intersects the curve.
-image::intersect2-1.png[Elliptic Curve Vertical Line]
+image::images/intersect2-1.png[Elliptic Curve Vertical Line]
 
 It turns out that even over a Finite Field, we have the same symmetry.
 
@@ -103,7 +103,7 @@ If `y` is even, it's `0x02`, otherwise it's `0x03`.
 The Compressed SEC format is in Figure 4-3:
 
 .Compressed SEC Format
-image::sec2.png[Compressed SEC Format]
+image::images/sec2.png[Compressed SEC Format]
 
 Again, the procedure is pretty straightforward.
 We can update the `sec` method to handle compressed SEC keys.
@@ -225,7 +225,7 @@ All numbers in an ECDSA signature are positive, so we have to prepend with `0x00
 The DER format is in Figure 4-4:
 
 .DER Format
-image::der.png[DER format]
+image::images/der.png[DER format]
 
 Because we know `r` is a 256-bit integer, `r` will be at most 32-bytes expressed as Big-Endian.
 It's also possible the first byte could be >= 0x80, so part 4 can be at most 33-bytes.

--- a/ch05.asciidoc
+++ b/ch05.asciidoc
@@ -26,7 +26,7 @@ We'll go through each component in depth.
 Figure 5-1 shows a hexadecimal dump of a typical transaction that shows which parts are which.
 
 .Transaction Components, Version, Inputs, Output and Locktime
-image::tx1.png[Transaction Version, Inputs, Outputs and Locktime]
+image::images/tx1.png[Transaction Version, Inputs, Outputs and Locktime]
 
 The differently highlighted parts represent Version, Inputs, Outputs and Locktime respectively.
 
@@ -84,7 +84,7 @@ Our method will be able to handle any sort of stream and return the `Tx` object 
 === Version
 
 .Version
-image::tx2.png[Version]
+image::images/tx2.png[Version]
 
 When you see a version number in something (Figure 5-2 shows an example), it's meant to give the receiver information about what the versioned thing is supposed to represent.
 If, for example, you are running Windows 3.1, that's a version number that's very different than Windows 8 or Windows 10.
@@ -101,7 +101,7 @@ include::code-ch05/answers.py[tag=exercise1,indent=0]
 === Inputs
 
 .Inputs
-image::tx3.png[Inputs]
+image::images/tx3.png[Inputs]
 
 Each input points to an output of a previous transaction (see Figure 5-3).
 This fact requires more explanation as it's not intuitively obvious at first.
@@ -129,7 +129,7 @@ This would be analogous to 14 inputs or 7000 inputs.
 The number of inputs is the next part of the transaction shown in Figure 5-4:
 
 .Number of Inputs
-image::tx4.png[Inputs]
+image::images/tx4.png[Inputs]
 
 We can see that the byte is actually `01`, which means that this transaction has 1 input.
 It may be tempting here to assume that it's always a single byte, but it's not.
@@ -191,7 +191,7 @@ Sequence is also in Little-Endian and takes up 4 bytes.
 The fields of the input look like Figure 5-5:
 
 .The Fields of an Input, Previous Tx, Previous Index, ScriptSig and Sequence
-image::tx5.png[Input Fields]
+image::images/tx5.png[Input Fields]
 
 .Sequence and Locktime
 ****
@@ -254,7 +254,7 @@ An exchange may batch transactions, for example, and pay out a lot of people at 
 Like inputs, the outputs serialization starts with how many outputs there are as a varint as shown in Figure 5-6.
 
 .Number of Outputs
-image::tx6.png[Outputs]
+image::images/tx6.png[Outputs]
 
 Each output has two fields: Amount and ScriptPubKey.
 Amount is the amount of Bitcoin being assigned and is specified in satoshis, or 1/100,000,000th of a Bitcoin.
@@ -272,7 +272,7 @@ Like ScriptSig, ScriptPubKey is a variable-length field and is preceded by the l
 An output field look like Figure 5-7:
 
 .Output Fields, Amount and ScriptPubKey. This one is at index 0.
-image::tx7.png[Output Fields]
+image::images/tx7.png[Output Fields]
 
 .UTXO Set
 ****
@@ -309,7 +309,7 @@ This way, transactions can be signed, but unspendable until a certain point in U
 The serialization is in Little-Endian and 4-bytes (Figure 5-8).
 
 .Locktime
-image::tx8.png[Locktime]
+image::images/tx8.png[Locktime]
 
 The main problem with using Locktime is that the recipient of the transaction has no certainty that the transaction will be good when the Locktime comes.
 This is similar to a post-dated bank check, which has the possibility of bouncing.

--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -64,18 +64,18 @@ They are byte strings of length 1 to 520.
 A typical element might be a DER signature or a SEC pubkey (Figure 6-1).
 
 .Elements
-image::script1.png[Script Elements]
+image::images/script1.png[Script Elements]
 
 Operations do something to the data (Figure 6-2).
 They consume zero or more elements from the processing stack and push zero or more elements back on the stack.
 
 .Operations
-image::script2.png[Script Operations]
+image::images/script2.png[Script Operations]
 
 A typical operation is `OP_DUP` (Figure 6-3), which will duplicate the top element (consuming 0) and pushing the new element to the stack (pushing 1).
 
 .`OP_DUP` duplicates the top element
-image::op_dup.png[OP_DUP]
+image::images/op_dup.png[OP_DUP]
 
 At the end of evaluating all the instructions, the top element of the stack must be non-zero for the Script to resolve as valid.
 Having no elements in the stack or the top element being zero would resolve as invalid.
@@ -88,14 +88,14 @@ There are many other operations besides `OP_DUP`.
 Note in the diagram that `y = hash160(x)`.
 
 .`OP_HASH160` does a sha256 followed by ripemd160 to the top element
-image::op_hash160.png[OP_HASH160]
+image::images/op_hash160.png[OP_HASH160]
 
 Another very important operation is `OP_CHECKSIG` (Figure 6-5).
 `OP_CHECKSIG` consumes 2 elements from the stack, the first being the pubkey, the second being a signature, and examines if the signature is good for the given pubkey.
 If so, `OP_CHECKSIG` pushes a 1 to the stack, otherwise pushes a 0 to the stack.
 
 .`OP_CHECKSIG` checks if the signature for the pubkey is valid or not
-image::op_checksig.png[OP_CHECKSIG]
+image::images/op_checksig.png[OP_CHECKSIG]
 
 ==== Coding opcodes
 
@@ -217,7 +217,7 @@ The input in the spending transaction _points to the receiving transaction_.
 Essentially, we have a situation like Figure 6-6:
 
 .ScriptPubKey and ScriptSig
-image::script3.png[ScriptPubKey and ScriptSig]
+image::images/script3.png[ScriptPubKey and ScriptSig]
 
 Since ScriptSig unlocks ScriptPubKey, we need a mechanism by which the two Scripts combine.
 To evaluate the two together, we take the instructions from ScriptSig and ScriptPubKey and combine them as above.
@@ -272,7 +272,7 @@ ScriptPubKey is the lockbox that receives the bitcoins.
 The p2pk ScriptPubKey looks like Figure 6-7:
 
 .Pay-to-pubkey (p2pk) ScriptPubKey
-image::p2pk1.png[P2PK ScriptPubKey]
+image::images/p2pk1.png[P2PK ScriptPubKey]
 
 Note the `OP_CHECKSIG`, as that will be very important.
 The ScriptSig is the part that unlocks the received bitcoins.
@@ -281,12 +281,12 @@ The pubkey can be compressed or uncompressed, though early on in Bitcoin's histo
 For p2pk, the ScriptSig required to unlock the corresponding ScriptPubKey is just the signature as shown in Figure 6-8:
 
 .Pay-to-pubkey (p2pk) ScriptSig
-image::p2pk2.png[P2PK ScriptSig]
+image::images/p2pk2.png[P2PK ScriptSig]
 
 The ScriptPubKey and ScriptSig combine to make an instruction set that looks like Figure 6-9:
 
 .p2pk Combined
-image::p2pk3.png[P2PK Combination]
+image::images/p2pk3.png[P2PK Combination]
 
 The two columns below are instructions of Script and the elements stack.
 At the end of this processing, the top element of the stack must be non-zero to be considered a valid ScriptSig.
@@ -294,26 +294,26 @@ The Script instructions are processed one instruction at a time.
 We start with the instructions as combined above (Figure 6-10):
 
 .p2pk Start
-image::p2pk4.png[P2PK Start]
+image::images/p2pk4.png[P2PK Start]
 
 The first instruction is the signature, which is an element.
 This is data that is pushed to the stack (Figure 6-11).
 
 .p2pk Step 1
-image::p2pk5.png[P2PK Step 1]
+image::images/p2pk5.png[P2PK Step 1]
 
 The second instruction is the pubkey, which is also an element.
 This is again, data is pushed to the stack (Figure 6-12).
 
 .p2pk Step 2
-image::p2pk6.png[P2PK Step 2]
+image::images/p2pk6.png[P2PK Step 2]
 
 `OP_CHECKSIG` consumes 2 stack instructions (pubkey and signature) and determines if they are valid for this transaction.
 `OP_CHECKSIG` will push a 1 to the stack if the signature is valid, 0 if not.
 Assuming that the signature is valid for this public key, we have this situation (Figure 6-13):
 
 .p2pk Step 3
-image::p2pk7.png[P2PK End 1]
+image::images/p2pk7.png[P2PK End 1]
 
 We're finished processing all the instructions of Script and we've ended with a single element on the stack.
 Since the top element is not zero, (1 is definitely not 0), this Script is valid.
@@ -321,7 +321,7 @@ Since the top element is not zero, (1 is definitely not 0), this Script is valid
 If this transaction instead had an invalid signature, the result from `OP_CHECKSIG` would be zero, ending our Script processing like Figure 6-14:
 
 .p2pk End
-image::p2pk8.png[P2PK End 2]
+image::images/p2pk8.png[P2PK End 2]
 
 We end with a single element on the stack which is zero.
 Since the top element is zero, the combined Script is invalid and a transaction with this ScriptSig in the input is invalid.
@@ -470,7 +470,7 @@ Pay-to-pubkey-hash was used during the early days of bitcoin, though not as much
 The p2pkh ScriptPubKey, or locking Script, looks like Figure 6-15:
 
 .Pay-to-pubkey-hash (p2pkh) ScriptPubKey
-image::p2pkh1.png[P2PKH ScriptPubKey]
+image::images/p2pkh1.png[P2PKH ScriptPubKey]
 
 Like p2pk, `OP_CHECKSIG` is here and `OP_HASH160` makes an appearance.
 Unlike p2pk, the SEC pubkey is not here but a 20 byte hash is.
@@ -479,7 +479,7 @@ There is also a new opcode here: `OP_EQUALVERIFY`.
 The p2pkh ScriptSig, or the unlocking Script, looks like Figure 6-16:
 
 .Pay-to-pubkey-hash (p2pkh) ScriptSig
-image::p2pkh2.png[P2PKH ScriptSig]
+image::images/p2pkh2.png[P2PKH ScriptSig]
 
 Like p2pk, the ScriptSig has the DER signature.
 Unlike p2pk, the ScriptSig also has the SEC pubkey.
@@ -488,33 +488,33 @@ The main difference between p2pk and p2pkh ScriptSigs is that the SEC pubkey has
 The ScriptPubKey and ScriptSig combine to a list of instructions that looks like Figure 6-17:
 
 .p2pkh Combined
-image::p2pkh3.png[P2PKH Combination]
+image::images/p2pkh3.png[P2PKH Combination]
 
 At this point, the Script is processed one instruction at a time.
 We start with the instructions as above (Figure 6-18).
 
 .p2pkh Start
-image::p2pkh4.png[P2PKH Start]
+image::images/p2pkh4.png[P2PKH Start]
 
 The first two instructions are elements, so they are pushed to the stack (Figure 6-19).
 
 .p2pkh Step 1
-image::p2pkh5.png[P2PKH Step 1]
+image::images/p2pkh5.png[P2PKH Step 1]
 
 `OP_DUP` duplicates the top element, so the pubkey gets duplicated (Figure 6-20):
 
 .p2pkh Step 2
-image::p2pkh6.png[P2PKH Step 2]
+image::images/p2pkh6.png[P2PKH Step 2]
 
 `OP_HASH160` takes the top element and performs the hash160 operation on it (sha256 followed by ripemd160), creating a 20-byte hash (Figure 6-21):
 
 .p2pkh Step 3
-image::p2pkh7.png[P2PKH Step 3]
+image::images/p2pkh7.png[P2PKH Step 3]
 
 The 20-byte hash is an element and is pushed to the stack (Figure 6-22).
 
 .p2pkh Step 4
-image::p2pkh8.png[P2PKH Step 4]
+image::images/p2pkh8.png[P2PKH Step 4]
 
 We are now at `OP_EQUALVERIFY`.
 This opcode consumes the top two elements and checks if they're equal.
@@ -523,13 +523,13 @@ If they are not equal, the Script stops immediately and fails.
 We assume here that they're equal, leading to Figure 6-23:
 
 .p2pkh Step 5
-image::p2pkh9.png[P2PKH Step 5]
+image::images/p2pkh9.png[P2PKH Step 5]
 
 We are now exactly where we were during the `OP_CHECKSIG` part of processing p2pk.
 Once again, we assume that the signature is valid (Figure 6-24):
 
 .p2pkh End
-image::p2pkh10.png[P2PKH End]
+image::images/p2pkh10.png[P2PKH End]
 
 There are two ways this Script can fail.
 If the ScriptSig provides a public key that does not hash160 to the 20-byte hash in the ScriptPubKey, the Script will fail at `OP_EQUALVERIFY` (Figure 6-22).
@@ -549,47 +549,47 @@ Script is a smart contract language and can lock Bitcoins in many different ways
 Figure 6-25 is an example ScriptPubKey:
 
 .Example ScriptPubKey
-image::ex1.png[Example 1 ScriptPubKey]
+image::images/ex1.png[Example 1 ScriptPubKey]
 
 Figure 6-26 is a ScriptSig that will unlock the the ScriptPubKey from Figure 6-25.
 
 .Example ScriptSig
-image::ex2.png[Example 1 ScriptSig]
+image::images/ex2.png[Example 1 ScriptSig]
 
 The combined Script is shown in Figure 6-27:
 
 .Example Combined
-image::ex3.png[Example 1 Combination]
+image::images/ex3.png[Example 1 Combination]
 
 Script evaluation will start like Figure 6-28:
 
 .Example Start
-image::ex4.png[Example 1 Start]
+image::images/ex4.png[Example 1 Start]
 
 `OP_4` will push a 4 to the stack (Figure 6-29).
 
 .Example Step 1
-image::ex5.png[Example 1 Step 1]
+image::images/ex5.png[Example 1 Step 1]
 
 `OP_5` will likewise push a 5 to the stack (Figure 6-30).
 
 .Example Step 2
-image::ex6.png[Example 1 Step 2]
+image::images/ex6.png[Example 1 Step 2]
 
 `OP_ADD` will consume the top two elements of the stack, add them together and push the sum to the stack (Figure 6-31).
 
 .Example Step 3
-image::ex7.png[Example 1 Step 3]
+image::images/ex7.png[Example 1 Step 3]
 
 `OP_9` will push a 9 to the stack (Figure 6-32).
 
 .Example Step 4
-image::ex8.png[Example 1 Step 4]
+image::images/ex8.png[Example 1 Step 4]
 
 `OP_EQUAL` will consume 2 elements and push a 1 if equal, 0 if not (Figure 6-33).
 
 .Example End
-image::ex9.png[Example 1 End]
+image::images/ex9.png[Example 1 End]
 
 Note that the ScriptSig isn't particularly hard to figure out and contains no signature.
 As a result, ScriptPubKey is vulnerable to being taken by anyone who can solve it.

--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -107,7 +107,7 @@ A naive way to get the signature hash would be to hash the transaction serializa
 Unfortunately, we can't do that since the signature is part of the ScriptSig and a signature can't sign itself.
 
 .A signature is in the yellow highlighted part, or the ScriptSig.
-image::validation1.png[Validation Start]
+image::images/validation1.png[Validation Start]
 
 Instead, we modify the transaction before signing it.
 That is, we compute a different signature hash, or `z`, _for each input_.
@@ -119,7 +119,7 @@ The first step is to empty all the ScriptSigs when checking the signature (Figur
 The same procedure is used for creating the signature, except the ScriptSigs are usually already empty.
 
 .Empty each input's ScriptSig (in yellow highlighted field)
-image::validation2.png[Validation Step 1]
+image::images/validation2.png[Validation Step 1]
 
 Note that this example has only 1 input, so only that input's ScriptSig is emptied, but it's possible to have more than 1 input. Each of those would be emptied.
 
@@ -128,13 +128,13 @@ Note that this example has only 1 input, so only that input's ScriptSig is empti
 Each input points to a previous transaction output, which has a ScriptPubKey. Recall the diagram from <<chapter_script>> shown in Figure 7-3.
 
 .ScriptPubKey and ScriptSig
-image::script3.png[ScriptPubKey and ScriptSig]
+image::images/script3.png[ScriptPubKey and ScriptSig]
 
 We take the ScriptPubKey that the input is pointing to and put that in place of the empty ScriptSig (Figure 7-4).
 This may require a lookup on the blockchain, but in practice, the signer already knows the ScriptPubKey as the input is one where the signer has the private key.
 
 .Replace the ScriptSig (yellow highlighted field) for one of the inputs with the previous ScriptPubKey
-image::validation3.png[Validation Step 2]
+image::images/validation3.png[Validation Step 2]
 
 ==== Step 3: Append the hash type
 
@@ -148,7 +148,7 @@ For `SIGHASH_ALL`, the final transaction must have the exact outputs that were s
 The integer corresponding to `SIGHASH_ALL` is 1 and this has to be encoded in Little-Endian over 4 bytes, which makes the modified transaction look like Figure 7-5:
 
 .Append the hash type (SIGHASH_ALL), or the orange `01000000`
-image::validation4.png[Validation Step 3]
+image::images/validation4.png[Validation Step 3]
 
 The hash256 of this modified transaction is interpreted as a Big-Endian integer to produce `z`.
 The code for converting the modified transaction to `z` looks like this:
@@ -240,7 +240,7 @@ In this example, we have an output here denoted by transaction ID and output ind
 When we view this output on a testnet block explorer (Figure 7-6), we can see that our output is worth 0.33 tBTC.
 
 .UTXO that we're spending
-image::txcreation1.png[Transaction seen on the blockchain]
+image::images/txcreation1.png[Transaction seen on the blockchain]
 
 Since this is more than 0.1 tBTC, we'll want to send the rest back to ourselves.
 Though it's generally bad privacy and security practice to reuse addresses, we'll send the bitcoins back to `mzx5YhAH9kNHtcN481u6WkjeHjYtVeKVh2` to make the transaction construction easier.

--- a/ch08.asciidoc
+++ b/ch08.asciidoc
@@ -34,48 +34,48 @@ The transaction output is called "bare" multisig because it's a long ScriptPubKe
 Figure 8-1 shows what a ScriptPubKey for a 1-of-2 multisig looks like.
 
 .Bare Multisig ScriptPubKey
-image::multisig1.png[Bare Multisig ScriptPubKey]
+image::images/multisig1.png[Bare Multisig ScriptPubKey]
 
 Among Bare Multisig ScriptPubKeys, this one is on the small end, and we can already see that it's long.
 The ScriptPubKey for p2pkh is only 25 bytes whereas this Bare Multisig is 101 bytes (though obviously, compressed SEC format would reduce it some), and this is a 1-of-2!
 Figure 8-2 shows what the ScriptSig looks like:
 
 .Bare Multisig ScriptSig
-image::multisig2.png[Bare Multisig ScriptSig]
+image::images/multisig2.png[Bare Multisig ScriptSig]
 
 We only need 1 signature for this 1-of-2 multisig, so this is relatively short, though something like a 5-of-7 would require 5 DER signatures and would be a lot longer (360 bytes or so).
 Figure 8-3 shows how the two combine.
 
 .Bare Multisig Combined Script.
-image::multisig3.png[Bare Multisig Combined Script]
+image::images/multisig3.png[Bare Multisig Combined Script]
 
 Note `m` and `n` are something between 1 and 16 inclusive.
 We've generalized here so we can see what a Bare m-of-n Multisig would look like (`m` and `n` can be anything from 1 to 20, though there's numerical opcodes only go up to `OP_16`, 17 to 20 would require `0112` to push a number like 18 to the stack).
 The starting state looks like Figure 8-4:
 
 .Bare Multisig Start
-image::multisig4.png[Bare Multisig Start]
+image::images/multisig4.png[Bare Multisig Start]
 
 `OP_0` will push the number `0` to the stack (Figure 8-5).
 
 .Bare Multisig Step 1
-image::multisig5.png[Bare Multisig Step 1]
+image::images/multisig5.png[Bare Multisig Step 1]
 
 The signatures are elements so they'll be pushed directly to the stack (Figure 8-6).
 
 .Bare Multisig Step 2
-image::multisig6.png[Bare Multisig Step 2]
+image::images/multisig6.png[Bare Multisig Step 2]
 
 `OP_m` will push the number `m` on the stack, the public keys will be pushed to the stack and `OP_n` will push the number `n` to the stack (Figure 8-7).
 
 .Bare Multisig Step 3
-image::multisig7.png[Bare Multisig Step 3]
+image::images/multisig7.png[Bare Multisig Step 3]
 
 At this point, `OP_CHECKMULTISIG` will consume `m+n+3` elements (see _`OP_CHECKMULTISIG` Off-by-one Bug_) and push a 1 to the stack if `m` of the signatures are valid for `m` distinct public keys from the list of `n` public keys, a 0 otherwise.
 Assuming that the signatures are valid, the stack has a single `1` which validates the combined Script (Figure 8-8):
 
 .Bare Multisig End
-image::multisig8.png[Bare Multisig End]
+image::images/multisig8.png[Bare Multisig End]
 
 [NOTE]
 .`OP_CHECKMULTISIG` Off-by-one Bug
@@ -147,7 +147,7 @@ There were multiple proposals, but as we'll see, p2sh is kludgy, but works.
 In p2sh, a special rule gets executed only when the pattern shown in Figure 8-9 is encountered:
 
 .Pay-to-script-hash Pattern that executes the special rule
-image::p2sh1.png[p2sh Pattern]
+image::images/p2sh1.png[p2sh Pattern]
 
 If this exact instruction set ends with a `1` on the stack, then the RedeemScript (top item in figure 8-9) is parsed and then added to the Script instruction set.
 This special pattern was introduced in BIP0016 and Bitcoin software that implements BIP0016 (anything post 2011) checks for the pattern.
@@ -159,7 +159,7 @@ But before we get to that, let's look a little closer at exactly how this plays 
 Let's say we have a 2-of-2 multisig ScriptPubKey (Figure 8-10):
 
 .Pay-to-script-hash (p2sh) RedeemScript
-image::p2sh2.png[p2sh RedeemScript]
+image::images/p2sh2.png[p2sh RedeemScript]
 
 This is a ScriptPubKey for a Bare Multisig.
 What we need to do to convert this to p2sh is to take a hash of this Script and keep this Script handy for when we want to redeem it.
@@ -167,7 +167,7 @@ We call this the RedeemScript, because the Script is only revealed during redemp
 We put the hash of the RedeemScript as the ScriptPubKey like Figure 8-11:
 
 .Pay-to-script-hash (p2sh) ScriptPubKey
-image::p2sh3.png[p2sh ScriptPubKey]
+image::images/p2sh3.png[p2sh ScriptPubKey]
 
 The hash digest here is the hash160 of the RedeemScript, or what was previously the ScriptPubKey.
 We're locked the funds to the _hash_ of the RedeemScript which needs to be revealed at unlock time.
@@ -187,18 +187,18 @@ Better yet, make it easy to reconstruct!
 The ScriptSig for the 2-of-2 multisig looks like Figure 8-12:
 
 .Pay-to-script-hash (p2sh) ScriptSig
-image::p2sh4.png[p2sh ScriptSig]
+image::images/p2sh4.png[p2sh ScriptSig]
 
 This produces the combined Script (Figure 8-13):
 
 .p2sh Combined
-image::p2sh5.png[p2sh Combined Script]
+image::images/p2sh5.png[p2sh Combined Script]
 
 As before, `OP_0` is there because of the `OP_CHECKMULTISIG` bug.
 The key to understanding p2sh is the execution of the exact sequence shown in Figure 8-14:
 
 .p2sh pattern that executes the special rule
-image::p2sh1.png[p2sh Pattern]
+image::images/p2sh1.png[p2sh Pattern]
 
 Upon execution of this sequence, if the stack is left with a `1`, the RedeemScript is inserted into the Script instruction set.
 In other words, if we reveal a RedeemScript whose hash160 is the same hash160 in the ScriptPubKey, that RedeemScript acts like the ScriptPubKey instead.
@@ -209,50 +209,50 @@ Let's go through exactly how this works.
 We start with the Script instructions (Figure 8-15):
 
 .p2sh Start
-image::p2sh6.png[p2sh Start]
+image::images/p2sh6.png[p2sh Start]
 
 `OP_0` will push a 0 to the stack, the two signatures and the RedeemScript will be pushed to the stack directly, leading to Figure 8-16:
 
 .p2sh Step 1
-image::p2sh7.png[p2sh Step 1]
+image::images/p2sh7.png[p2sh Step 1]
 
 `OP_HASH160` will hash the RedeemScript, which will make the stack look like Figure 8-17:
 
 .p2sh Step 2
-image::p2sh8.png[p2sh Step 2]
+image::images/p2sh8.png[p2sh Step 2]
 
 The 20-byte hash will be pushed on the stack (Figure 8-18):
 
 .p2sh Step 3
-image::p2sh9.png[p2sh Step 3]
+image::images/p2sh9.png[p2sh Step 3]
 
 And finally, `OP_EQUAL` will compare the top two elements.
 If the software checking this transaction is pre-BIP0016, we would end up with Figure 8-19:
 
 .p2sh End if evaluating with pre-BIP0016 software
-image::p2sh10.png[p2sh pre-BIP0016 End]
+image::images/p2sh10.png[p2sh pre-BIP0016 End]
 
 This would end evaluation for pre-BIP0016 nodes and the result would be valid, assuming the hashes are equal.
 
 On the other hand, BIP0016 nodes, which as of this writing are the vast majority, will parse the RedeemScript as Script instructions (Figure 8-20):
 
 .p2sh RedeemScript
-image::p2sh2.png[p2sh RedeemScript]
+image::images/p2sh2.png[p2sh RedeemScript]
 
 These go into the Script column as instructions (Figure 8-21):
 
 .p2sh Step 4
-image::p2sh11.png[p2sh Step 4]
+image::images/p2sh11.png[p2sh Step 4]
 
 `OP_2` pushes a `2` to the stack, the pubkeys are also pushed and a final `OP_2` pushes another `2` to the stack (Figure 8-22):
 
 .p2sh Step 5
-image::p2sh12.png[p2sh Step 5]
+image::images/p2sh12.png[p2sh Step 5]
 
 `OP_CHECKMULTISIG` consumes m+n+3 elements, which is the entire stack, and we end the same way we did Bare Multisig (Figure 8-23).
 
 .p2sh End for post-BIP0016 software
-image::p2sh13.png[p2sh End]
+image::images/p2sh13.png[p2sh End]
 
 The RedeemScript substitution is a bit hacky and there's special-cased code in Bitcoin software to handle this.
 Why wasn't something a lot less hacky and more intuitive chosen?
@@ -260,7 +260,7 @@ BIP0012 was a competing proposal at the time which used `OP_EVAL` and was consid
 A ScriptPubKey like Figure 8-24 would have worked with BIP0012:
 
 .`OP_EVAL` would have been an instruction which adds additional instructions based on the top element.
-image::op_eval.png[`OP_EVAL`]
+image::images/op_eval.png[`OP_EVAL`]
 
 `OP_EVAL` would have consumed the top element of the stack and interpreted that as Script instructions to be put into the Script column.
 
@@ -332,7 +332,7 @@ Thankfully, signatures have to be in the same order as the pubkeys or the signat
 Once we have a particular signature and public key, we only need the signature hash, or `z` to figure out whether the signature is valid (Figure 8-25).
 
 .Validation of p2sh Inputs
-image::verifyp2sh1.png[Validation Start]
+image::images/verifyp2sh1.png[Validation Start]
 
 As with p2pkh, finding the signature hash is the most difficult part of the p2sh signature validation process and we'll now proceed to cover this in detail.
 
@@ -342,7 +342,7 @@ The first step is to empty all the ScriptSigs when checking the signature (Figur
 The same procedure is used for creating the signature.
 
 .Empty each input's ScriptSig
-image::verifyp2sh2.png[Validation Step 1]
+image::images/verifyp2sh2.png[Validation Step 1]
 
 ==== Step 2: Replace the ScriptSig of the p2sh input being signed with the RedeemScript
 
@@ -351,7 +351,7 @@ We take the RedeemScript and put that in place of the empty ScriptSig (Figure 8-
 This is different from p2pkh in that it's not the ScriptPubKey.
 
 .Replace the ScriptSig of the input we're checking with the RedeemScript
-image::verifyp2sh3.png[Validation Step 2]
+image::images/verifyp2sh3.png[Validation Step 2]
 
 ==== Step 3: Append the hash type
 
@@ -361,7 +361,7 @@ This is the same as in p2pkh.
 The integer corresponding to `SIGHASH_ALL` is 1 and this has to be encoded in Little-Endian over 4 bytes, which makes the transaction look like this:
 
 .Append the hash type `SIGHASH_ALL`, or the blue part at the end.
-image::verifyp2sh4.png[Validation Step 3]
+image::images/verifyp2sh4.png[Validation Step 3]
 
 The hash256 of this interpreted as a Big-Endian integer is our `z`.
 The code for getting our signature hash, or `z`, looks like this:
@@ -374,7 +374,7 @@ include::code-ch08/examples.py[tag=example2]
 Now that we have our `z`, we can grab the SEC public key and DER signature from the ScriptSig and RedeemScript  (Figure 8-29):
 
 .DER and SEC within the p2sh ScriptSig and RedeemScript
-image::p2sh-sigelements.png[DER and SEC]
+image::images/p2sh-sigelements.png[DER and SEC]
 
 [source,python]
 ----

--- a/ch09.asciidoc
+++ b/ch09.asciidoc
@@ -31,7 +31,7 @@ The Coinbase transaction is what makes it worthwhile for a miner to mine.
 Figure 9-1 shows what a Coinbase transaction looks like:
 
 .Coinbase Transaction
-image::coinbase1.png[Coinbase Transaction]
+image::images/coinbase1.png[Coinbase Transaction]
 
 The transaction structure is no different than other transactions on the Bitcoin network with a few exceptions.
 
@@ -105,7 +105,7 @@ The block header as shown in Figure 9-2 consists of:
 * Nonce
 
 .Parsed Block
-image::block1.png[Block Parsing]
+image::images/block1.png[Block Parsing]
 
 The Block Header is the metadata for the block.
 Unlike transactions, each field in a block header is of a fixed length.

--- a/ch10.asciidoc
+++ b/ch10.asciidoc
@@ -19,7 +19,7 @@ With that in mind, we'll work in this chapter toward requesting, receiving and v
 All network messages looks like Figure 10-1:
 
 .Network Message or the Envelope that contains the actual payload
-image::network1.png[Network Message]
+image::images/network1.png[Network Message]
 
 The first four bytes are always the same and are referred to as the *network magic*.
 Magic bytes are common in network programming as the communication is asynchronous and can be intermittent.
@@ -62,7 +62,7 @@ Each command has a separate payload specification.
 Figure 10-2 is the parsed payload for Version:
 
 .Parsed Version
-image::network2.png[Version Message]
+image::images/network2.png[Version Message]
 
 The fields for Version are meant to give enough information for two nodes to be able to communicate.
 
@@ -197,7 +197,7 @@ Nodes can give us the block headers without taking up much bandwidth.
 The command to get the block headers is called `getheaders` and it looks like Figure 10-3:
 
 .Parsed `getheaders`
-image::getheaders.png[GetHeaders payload]
+image::images/getheaders.png[GetHeaders payload]
 
 As with Version, we start with the protocol version, then the number of block headers in this list (this number can be more than 1 if there's a chain split), then the starting block headers and lastly, the ending block header.
 If we specify the ending block to be `000...000`, we're indicating that we want as many as the other node will give us.
@@ -238,7 +238,7 @@ The headers command is a list of block headers (Figure 10-4) which we already le
 The `HeadersMessage` class can take advantage when parsing.
 
 .Parsed `headers`
-image::headers.png[headers payload]
+image::images/headers.png[headers payload]
 
 The Headers message starts with the number of headers as a varint, which is a number from 1 to 2000 inclusive.
 Each block header, we know, is 80 bytes.

--- a/ch11.asciidoc
+++ b/ch11.asciidoc
@@ -51,7 +51,7 @@ The idea is to come to a single hash that "represents" the entire ordered list.
 Visually, a Merkle Tree looks like Figure 11-1:
 
 .Merkle Tree
-image::merkle1.png[Merkle Tree]
+image::images/merkle1.png[Merkle Tree]
 
 The bottom row is what we call the leaves of the tree.
 All other nodes besides the leaves are called *internal nodes*.
@@ -183,7 +183,7 @@ Now that we know how a Merkle Tree is constructed, we can create and verify Proo
 Light nodes can get proofs that transactions of interest were included in a block without having to know all the transactions of a block (Figure 11-2).
 
 .Merkle Proof
-image::merkleproof.png[Merkle Proof]
+image::images/merkleproof.png[Merkle Proof]
 
 Say that a light client has two transactions that are of interest, which would be the hashes represented by the green boxes, H~K~ and H~N~ above.
 A full node can construct a Proof of Inclusion by sending us all of the hashes marked by blue boxes, H~ABCDEFGH~, H~IJ~, H~L~, H~M~ and H~OP~.
@@ -228,19 +228,19 @@ In a binary tree, nodes can be traversed breadth-first or depth-first.
 Breadth-first traversal would go level by level like Figure 11-3:
 
 .Breadth-First Ordering
-image::breadthfirst.png[Breadth First]
+image::images/breadthfirst.png[Breadth First]
 
 The breadth-first ordering starts at the root and goes from root to leaves, level by level, left to right.
 
 Depth-first ordering is a bit different and looks like Figure 11-4:
 
 .Depth-First Ordering
-image::depthfirst.png[Depth First]
+image::images/depthfirst.png[Depth First]
 
 The depth-first ordering starts at the root, traverses the left side at each node before the right side.
 
 .Merkle Proof
-image::merkleproof.png[Merkle Proof]
+image::images/merkleproof.png[Merkle Proof]
 
 In a Proof of Inclusion (see Figure 11-5), the full node sends the green boxes, H~K~ and H~N~ along with the blue boxes H~ABCDEFGH~, H~IJ~, H~L~, H~M~ and H~OP~.
 The location of each hash is reconstructed using depth-first ordering from some flags.
@@ -351,7 +351,7 @@ The full node communicating a Merkle Block sends all the information needed to v
 The `merkleblock` network command is what communicates this information and looks like Figure 11-6:
 
 .Parsed `merkleblock`
-image::merkleblock.png[merkleblock command]
+image::images/merkleblock.png[merkleblock command]
 
 The first 6 fields are exactly the same as the block header from <<chapter_blocks>>.
 The last 4 fields are the Proof of Inclusion.
@@ -384,7 +384,7 @@ The rules for the flag bits are:
 These are the items in the Merkle Tree being proven to be included.
 
 .Processing a Merkle Block
-image::merkleproof2.png[Merkle Blocks and Hashes]
+image::images/merkleproof2.png[Merkle Blocks and Hashes]
 
 Given a tree from Figure 11-7, the flag bit is 1 for the root node (1), since that hash is calculated by the light node.
 The left child, H~ABCDEFGH~ (2), is included in the hashes field, so the flag is 0.

--- a/ch12.asciidoc
+++ b/ch12.asciidoc
@@ -45,7 +45,7 @@ include::code-ch12/examples.py[tag=example1]
 Conceptually, what we just did looks like Figure 12-1:
 
 .10-bit Bloom Filter with 1 element
-image::bloomfilter1.png[Simple Bloom Filter]
+image::images/bloomfilter1.png[Simple Bloom Filter]
 
 Our Bloom Filter consists of:
 
@@ -61,7 +61,7 @@ The full node can then send multiple buckets of transactions instead of a single
 Let's create a Bloom Filter with two items, "hello world" and "goodbye" (Figure 12-2)
 
 .10-bit Bloom Filter with 2 elements
-image::bloomfilter2.png[Two Item Bloom Filter]
+image::images/bloomfilter2.png[Two Item Bloom Filter]
 
 [source,python]
 ----
@@ -97,7 +97,7 @@ include::code-ch12/examples.py[tag=example3]
 Conceptually, Figure 12-3 shows what the code above does:
 
 .10-bit Bloom Filter with 2 elements and 2 hash functions
-image::bloomfilter3.png[Multiple Hash Functions]
+image::images/bloomfilter3.png[Multiple Hash Functions]
 
 A Bloom Filter can be optimized by changing the number of hash functions and bit field size to get a desirable false-positive rate.
 
@@ -161,7 +161,7 @@ The command to set the Bloom Filter is called `filterload`.
 The payload looks like Figure 12-4:
 
 .Parsed `filterload`
-image::filterload.png[filterload Command]
+image::images/filterload.png[filterload Command]
 
 The elements of a Bloom Filter are encoded into bytes. The bit field, hash function count and tweak are encoded in this message.
 The last field, matched item flag, is a way of asking the full node to add any matched transactions to the Bloom Filter.
@@ -179,7 +179,7 @@ In other words, the light client can ask for Merkle Blocks whose transactions of
 Here is what the payload for `getdata` looks like Figure 12-5:
 
 .Parsed `getdata`
-image::getdata.png[getdata Command]
+image::images/getdata.png[getdata Command]
 
 The number of items as a varint specify how many items we want.
 The each item has a type.

--- a/ch13.asciidoc
+++ b/ch13.asciidoc
@@ -65,10 +65,10 @@ This is similar to how p2sh works (<<chapter_p2sh>>) in that newer nodes do addi
 To understand Segwit, it helps to look at what the transaction looks like when sent to an old node (Figure 13-1) versus a new node (Figure 13-2):
 
 .Pay-to-witness-pubkey-hash as seen by pre-BIP0141 software
-image::p2wpkh1.png[p2wpkh to old nodes]
+image::images/p2wpkh1.png[p2wpkh to old nodes]
 
 .Pay-to-witness-pubkey-hash as seen by post-BIP0141 software
-image::p2wpkh2.png[p2wpkh to new nodes]
+image::images/p2wpkh2.png[p2wpkh to new nodes]
 
 The difference between these two serializations is that the latter transaction (Segwit serialization) has the marker, flag and Witness fields.
 Otherwise, the two transactions look similar.
@@ -82,22 +82,22 @@ The ScriptSig, as seen in both serializations is empty.
 The combined Script is Figure 13-3:
 
 .Pay-to-witness-pubkey-hash (p2wpkh) ScriptPubKey
-image::p2wpkh3.png[p2wpkh ScriptPubKey]
+image::images/p2wpkh3.png[p2wpkh ScriptPubKey]
 
 The processing of the combined Script starts like Figure 13-4:
 
 .p2wpkh Start
-image::p2wpkh4.png[p2wpkh Start]
+image::images/p2wpkh4.png[p2wpkh Start]
 
 `OP_0` pushes a `0` on the stack (Figure 13-5):
 
 .p2wpkh Step 1
-image::p2wpkh5.png[p2wpkh Step 1]
+image::images/p2wpkh5.png[p2wpkh Step 1]
 
 The 20-byte hash is an element, so it's pushed to the stack (Figure 13-6):
 
 .p2wpkh Step 2
-image::p2wpkh6.png[p2wpkh Step 2]
+image::images/p2wpkh6.png[p2wpkh Step 2]
 
 At this point, older nodes will stop as there are no more Script instructions to be processed.
 Since the top element is non-zero, this will be counted as a valid Script.
@@ -111,13 +111,13 @@ Namely: `<signature> <pubkey> OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP
 Figure 13-7 shows the state that is encountered next:
 
 .p2wpkh Step 3
-image::p2wpkh7.png[p2wpkh Step 3]
+image::images/p2wpkh7.png[p2wpkh Step 3]
 
 The rest of the processing of p2wpkh is the same as the processing of p2pkh as seen in <<chapter_script>>.
 The end state is a single `1` on the stack if and only if the 20-byte hash is the hash160 of the pubkey and the signature is valid (Figure 13-8):
 
 .p2wpkh Step 4
-image::p2wpkh13.png[p2wpkh Step 4]
+image::images/p2wpkh13.png[p2wpkh Step 4]
 
 For an older node, processing stops at `<20-byte hash> 0`, as older nodes don't know the special Segwit rule.
 Only upgraded nodes do the rest of the validation, much like p2sh.
@@ -145,10 +145,10 @@ A p2sh-p2wpkh address is a normal p2sh address, but the RedeemScript is `OP_0 <2
 As with p2wpkh, different transactions are sent to older nodes (Figure 13-9) versus newer nodes (Figure 13-10):
 
 .Pay-to-script-hash-pay-to-witness-pubkey-hash (p2sh-p2wpkh) to pre-BIP0141 software
-image::p2sh-p2wpkh1.png[p2sh-p2wpkh to Old Nodes]
+image::images/p2sh-p2wpkh1.png[p2sh-p2wpkh to Old Nodes]
 
 .p2sh-p2wpkh to post-BIP0141 software
-image::p2sh-p2wpkh2.png[p2sh-p2wpkh to New Nodes]
+image::images/p2sh-p2wpkh2.png[p2sh-p2wpkh to New Nodes]
 
 The difference versus p2wpkh is that the ScriptSig is no longer empty.
 The ScriptSig has a RedeemScript which is equal to the ScriptPubkey in p2wpkh.
@@ -156,28 +156,28 @@ As this is a p2sh, the ScriptPubKey is the same as any other p2sh.
 The combined Script looks like Figure 13-11:
 
 .p2sh-p2wpkh ScriptPubKey is the same as a normal p2sh ScriptPubKey
-image::p2sh-p2wpkh3.png[p2sh-p2wpkh ScriptPubKey]
+image::images/p2sh-p2wpkh3.png[p2sh-p2wpkh ScriptPubKey]
 
 We start the Script evaluation like Figure 13-12:
 
 .p2sh-p2wpkh Start
-image::p2sh-p2wpkh4.png[p2sh-p2wpkh Start]
+image::images/p2sh-p2wpkh4.png[p2sh-p2wpkh Start]
 
 Notice that the instructions to be processed are exactly what triggers the p2sh Special rule.
 The RedeemScript goes on the stack (Figure 13-13):
 
 .p2sh-p2wpkh Step 1
-image::p2sh-p2wpkh5.png[p2sh-p2wpkh Step 1]
+image::images/p2sh-p2wpkh5.png[p2sh-p2wpkh Step 1]
 
 The `OP_HASH160` will turn the RedeemScript's hash (Figure 13-14):
 
 .p2sh-p2wpkh Step 2
-image::p2sh-p2wpkh6.png[p2sh-p2wpkh Step 2]
+image::images/p2sh-p2wpkh6.png[p2sh-p2wpkh Step 2]
 
 The hash will go on the stack and we then get to `OP_EQUAL` (Figure 13-15):
 
 .p2sh-p2wpkh Step 3
-image::p2sh-p2wpkh7.png[p2sh-p2wpkh Step 3]
+image::images/p2sh-p2wpkh7.png[p2sh-p2wpkh Step 3]
 
 At this point, if the hashes are equal, pre-BIP0016 nodes will simply mark the input as valid as they are unaware of the p2sh validation rules.
 However, post-BIP0016 nodes recognize the special Script sequence for p2sh, so the RedeemScript will then be evaluated as Script instructions.
@@ -185,26 +185,26 @@ The RedeemScript is `OP_0 <20-byte hash>`, which is the same as the ScriptPubKey
 This makes the Script state look like Figure 13-16:
 
 .p2sh-p2wpkh Step 4
-image::p2sh-p2wpkh8.png[p2sh-p2wpkh Step 4]
+image::images/p2sh-p2wpkh8.png[p2sh-p2wpkh Step 4]
 
 This should look familiar as this is the state that p2wpkh starts with.
 After `OP_0` and the 20-byte hash we are left with Figure 13-17:
 
 .p2sh-p2wpkh Step 5
-image::p2sh-p2wpkh9.png[p2sh-p2wpkh Step 5]
+image::images/p2sh-p2wpkh9.png[p2sh-p2wpkh Step 5]
 
 At this point, pre-Segwit nodes will mark this input as valid as they are unaware of the Segwit validation rules.
 However, post-Segwit nodes will recognize the special Script sequence for p2wpkh.
 The signature and pubkey from the Witness field along with the 20-byte hash will add the p2pkh instructions (Figure 13-18):
 
 .p2sh-p2wpkh Step 6
-image::p2sh-p2wpkh10.png[p2sh-p2wpkh Step 6]
+image::images/p2sh-p2wpkh10.png[p2sh-p2wpkh Step 6]
 
 The rest of the processing is the same as p2pkh (<<chapter_script>>).
 Assuming the signature and pubkey are valid, we are left with FIgure 13-19:
 
 .p2sh-p2wpkh End
-image::p2sh-p2wpkh11.png[p2sh-p2wpkh End]
+image::images/p2sh-p2wpkh11.png[p2sh-p2wpkh End]
 
 As you can see, a p2sh-p2wpkh transaction is backwards compatible all the way to before BIP0016.
 A node pre-BIP0016 would consider the Script valid once the RedeemScripts were equal and a post-BIP0016, pre-Segwit node would consider the Script valid at the 20-byte hash.
@@ -352,10 +352,10 @@ Pay-to-witness-script-hash is like p2sh, but with all the ScriptSig data in the 
 As with p2wpkh, we send different data to pre-BIP0141 software (Figure 13-20) vs post-BIP0141 software (Figure 13-21):
 
 .Pay-to-witness-script-hash as seen by pre-BIP0141 software
-image::p2wsh-3.png[p2wsh to old nodes]
+image::images/p2wsh-3.png[p2wsh to old nodes]
 
 .Pay-to-witness-script-hash as seen by post-BIP0141 software
-image::p2wsh-4.png[p2wsh to new nodes]
+image::images/p2wsh-4.png[p2wsh to new nodes]
 
 The ScriptPubKey for a p2wsh is `OP_0 <32-byte hash>`.
 This sequence triggers another special rule.
@@ -363,20 +363,20 @@ The ScriptSig, as with p2wpkh, is empty.
 When p2wsh is being spent, the combined Script looks like Figure 13-22:
 
 .Pay-to-witness-script-hash (p2wsh) ScriptPubKey
-image::p2wsh-8.png[p2wsh ScriptPubKey]
+image::images/p2wsh-8.png[p2wsh ScriptPubKey]
 
 The processing of this Script starts similarly to p2wpkh (Figure 13-23 and 13-24):
 
 .p2sh Start
-image::p2wsh-9.png[p2wsh Start]
+image::images/p2wsh-9.png[p2wsh Start]
 
 .p2wsh Step 1
-image::p2wsh-10.png[p2wsh Step 1]
+image::images/p2wsh-10.png[p2wsh Step 1]
 
 The 32-byte hash is an element, so is pushed to the stack (Figure 13-25):
 
 .p2wsh Step 2
-image::p2wsh-11.png[p2wsh Step 2]
+image::images/p2wsh-11.png[p2wsh Step 2]
 
 As with p2wpkh, older nodes will stop as there are no more Script instructions to be processed.
 Newer nodes will recognize the special sequence and do additional validation by looking at the Witness field.
@@ -384,7 +384,7 @@ Newer nodes will recognize the special sequence and do additional validation by 
 The Witness field for p2wsh in our case is a 2-of-3 multisig (Figure 13-26):
 
 .p2wsh Witness
-image::p2wsh-6.png[p2wsh Witness]
+image::images/p2wsh-6.png[p2wsh Witness]
 
 The last item of the Witness is called the *WitnessScript* and must sha256 to the 32-byte hash from the ScriptPubKey.
 Note this is sha256, not hash256.
@@ -392,22 +392,22 @@ Once the WitnessScript is validated by having the same hash value, the WitnessSc
 The Witness Script looks like Figure 13-27:
 
 .p2wsh Witness Script
-image::p2wsh-7.png[p2wsh Witness Script]
+image::images/p2wsh-7.png[p2wsh Witness Script]
 
 The rest of the Witness field is put on top to produce this instruction set (Figure 13-28):
 
 .p2wsh Step 3
-image::p2wsh-12.png[p2wsh Step 3]
+image::images/p2wsh-12.png[p2wsh Step 3]
 
 As you can see, this is a 2-of-3 multisig much like what was explored in <<chapter_p2sh>> (Figure 13-29).
 
 .p2wsh Step 4
-image::p2wsh-13.png[p2wsh Step 4]
+image::images/p2wsh-13.png[p2wsh Step 4]
 
 If the signatures are valid, we end like Figure 13-30:
 
 .p2wsh Step 5
-image::p2wsh-14.png[p2wsh Step 5]
+image::images/p2wsh-14.png[p2wsh Step 5]
 
 The WitnessScript is very similar to the RedeemScript in that the sha256 of the serialization is addressed in the ScriptPubKey, but only revealed when being spent.
 Once the sha256 of the WitnessScript is found to be the same as the 32-byte hash, the WitnessScript is interpreted as Script instructions and added to the instruction set.
@@ -420,78 +420,78 @@ Like p2sh-p2wpkh, p2sh-p2wsh is a way to make p2wsh backward-compatible.
 These transactions are sent to older nodes (Figure 13-31) vs newer nodes (Figure 13-32):
 
 .Pay-to-script-hash-pay-to-witness-script-hash (p2sh-p2wsh) to pre-BIP0141 software
-image::p2sh-p2wsh-4.png[p2sh-p2wsh to Old Nodes]
+image::images/p2sh-p2wsh-4.png[p2sh-p2wsh to Old Nodes]
 
 .p2sh-p2wsh to post-BIP0141 software
-image::p2sh-p2wsh-1.png[p2sh-p2wsh to New Nodes]
+image::images/p2sh-p2wsh-1.png[p2sh-p2wsh to New Nodes]
 
 As with p2sh-p2wpkh, the ScriptPubKey is indistinguishable from any other p2sh and the ScriptSig is only the RedeemScript (Figure 13-33):
 
 .p2sh-p2wsh ScriptPubKey
-image::p2sh-p2wpkh3.png[p2sh-p2wsh ScriptPubKey]
+image::images/p2sh-p2wpkh3.png[p2sh-p2wsh ScriptPubKey]
 
 We start the p2sh-p2wsh in exactly the same way that p2sh-p2wpkh starts (Figure 13-34).
 
 .p2sh-p2wsh Start
-image::p2sh-p2wpkh4.png[p2sh-p2wsh Start]
+image::images/p2sh-p2wpkh4.png[p2sh-p2wsh Start]
 
 The RedeemScript is pushed to the stack (Figure 13-35):
 
 .p2sh-p2wsh Step 1
-image::p2sh-p2wpkh5.png[p2sh-p2wsh Step 1]
+image::images/p2sh-p2wpkh5.png[p2sh-p2wsh Step 1]
 
 The `OP_HASH160` will return the RedeemScript's hash (Figure 13-36):
 
 .p2sh-p2wsh Step 2
-image::p2sh-p2wpkh6.png[p2sh-p2wsh Step 2]
+image::images/p2sh-p2wpkh6.png[p2sh-p2wsh Step 2]
 
 The hash is pushed to the stack and we then get to `OP_EQUAL` (Figure 13-37):
 
 .p2sh-p2wsh Step 3
-image::p2sh-p2wpkh7.png[p2sh-p2wsh Step 3]
+image::images/p2sh-p2wpkh7.png[p2sh-p2wsh Step 3]
 
 As with p2sh-p2wpkh, if the hashes are equal, pre-BIP0016 nodes will mark the input as valid as they are unaware of the p2sh validation rules.
 However, post-BIP0016 nodes will recognize the special Script sequence for p2sh, so the RedeemScript will be interpreted as new Script instructions.
 The RedeemScript is `OP_0 <32-byte hash>`, which is the same as the ScriptPubKey for p2wsh (Figure 13-38).
 
 .p2sh-p2wsh RedeemScript
-image::p2sh-p2wsh-6.png[p2sh-p2wsh RedeemScript]
+image::images/p2sh-p2wsh-6.png[p2sh-p2wsh RedeemScript]
 
 This makes the Script state look like Figure 13-39:
 
 .p2sh-p2wsh Step 4
-image::p2wsh-9.png[p2sh-p2wsh Step 4]
+image::images/p2wsh-9.png[p2sh-p2wsh Step 4]
 
 Of course, this is the exact same starting state as p2wsh (Figure 13-40).
 
 .p2sh-p2wsh Step 5
-image::p2wsh-10.png[p2sh-p2wsh Step 5]
+image::images/p2wsh-10.png[p2sh-p2wsh Step 5]
 
 The 32-byte hash is an element, so is pushed to the stack (Figure 13-41):
 
 .p2sh-p2wsh Step 6
-image::p2wsh-11.png[p2sh-p2wsh Step 6]
+image::images/p2wsh-11.png[p2sh-p2wsh Step 6]
 
 At this point, pre-Segwit nodes will mark this input as valid as they are unaware of the Segwit validation rules.
 However, post-Segwit nodes will recognize the special Script sequence for p2wsh.
 The Witness field (Figure 13-42) contains the Witness Script (Figure 13-43). The sha256 of the WitnessScript is checked against 32-byte hash and if equal, the WitnessScript is interpreted as Script and put into the instruction set (Figure 13-44):
 
 .p2sh-p2wsh Witness
-image::p2sh-p2wsh-8.png[p2sh-p2wsh Witness]
+image::images/p2sh-p2wsh-8.png[p2sh-p2wsh Witness]
 
 .p2sh-p2wsh Witness Script
-image::p2wsh-7.png[p2wsh Witness Script]
+image::images/p2wsh-7.png[p2wsh Witness Script]
 
 The Witness Script is a 2-of-3 multisig which is put into the instruction set (Figure 13-44):
 
 .p2sh-p2wsh Step 7
-image::p2wsh-12.png[p2sh-p2wsh Step 7]
+image::images/p2wsh-12.png[p2sh-p2wsh Step 7]
 
 As you can see, this is a 2-of-3 multisig as in <<chapter_p2sh>>.
 If the signatures are valid, we end like Figure 13-45:
 
 .p2sh-p2wsh End
-image::p2wsh-14.png[p2sh-p2wsh End]
+image::images/p2wsh-14.png[p2sh-p2wsh End]
 
 This makes p2wsh backwards compatible, allowing older wallets to send to p2sh ScriptPubKeys which they can handle.
 

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -157,17 +157,17 @@ Run Jupyter notebook:
 You should have a browser open up automatically:
 
 .Jupyter
-image::jupyter1.png[Jupyter]
+image::images/jupyter1.png[Jupyter]
 
 You can navigate to chapter directories. To do the exercises from <<chapter_finite_fields>>, you would navigate to `code-ch01`:
 
 .Jupyter Directory View
-image::jupyter2.png[Chapter 1 Directory]
+image::images/jupyter2.png[Chapter 1 Directory]
 
 From here you can open `Chapter1.ipynb`:
 
 .Jupyter Notebook
-image::jupyter3.png[Chapter 1 Notebook]
+image::images/jupyter3.png[Chapter 1 Notebook]
 
 You may want to familiarize yourself with this interface if you haven't seen it before, but the gist of Jupyter is that it can run Python code from the browser in a way to make experimenting easy.
 You can run each "cell" and see the results as if this were an interactive Python shell.
@@ -179,7 +179,7 @@ You will need to edit the corresponding file by clicking through a link like the
 This will take you to a browser tab like this:
 
 .ecc.py
-image::jupyter4.png[Chapter 1 ecc.py]
+image::images/jupyter4.png[Chapter 1 ecc.py]
 
 You can edit the file here and save in order to make the test pass.
 

--- a/sample_chapter.asciidoc
+++ b/sample_chapter.asciidoc
@@ -54,7 +54,7 @@ You can also specify inline text as code: +print "Hello World"+.
 Now, let's take a look at a figure with a caption:
 
 .Figures like this will be automatically numbered in output.
-image::images/tarsier.png["Drawing of Tarsiers"]
+image::images/images/tarsier.png["Drawing of Tarsiers"]
 
 Here is a blockquote with an author attribution:
 


### PR DESCRIPTION
The images in all `.asciidoc` had missing part to their path. Not sure if there was a reason for that but I fixed the path so that the images will be displayed.