### PR TITLE
Chapter 6 script.py code - fixed raw_serialize() of Script class for edge case

### DIFF
--- a/code-ch06/script.py
+++ b/code-ch06/script.py
@@ -83,7 +83,7 @@ class Script:
                 result += int_to_little_endian(cmd, 1)
             else:
                 length = len(cmd)
-                if length < 75:  # <2>
+                if length <= 75:  # <2>
                     result += int_to_little_endian(length, 1)
                 elif length > 75 and length < 0x100:  # <3>
                     result += int_to_little_endian(76, 1)


### PR DESCRIPTION
I fixed the `raw_serialize()` method in the `Script` class to account for the case when the number of bytes in the given `cmd` is exactly `75` (which currently incorrectly raises a `too long an cmd` error).