### PR TITLE
Ch 4: typo in prepending byte for DER

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -259,7 +259,7 @@ Add this to the result.
 
 The rules for #4 and #6 with the first byte starting with something greater than or equal to `0x80` are because DER is a general encoding and allows for negative numbers to be encoded.
 The first bit being 1 means that the number is negative.
-All numbers in an ECDSA signature are positive, so we have to prepend with `0x00` if the first bit is zero, which is equivalent to first byte &ge; `0x80`.
+All numbers in an ECDSA signature are positive, so we have to prepend with `0x00` if the first bit is 1, which is equivalent to first byte &ge; `0x80`.
 
 The DER format is shown in <<der_format>>.
 


### PR DESCRIPTION
Simple typo: passage explaining prepending `\x00` if high bit is set in the first byte mistakenly says "if first bit is zero" instead of "if first bit is 1".  