### PR TITLE
pip automatically installed since 3.4

### DIFF
--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -79,15 +79,6 @@ Windows:: https://www.python.org/ftp/python/3.6.2/python-3.6.2-amd64.exe[]
 macOS:: https://www.python.org/ftp/python/3.6.2/python-3.6.2-macosx10.6.pkg[]
 Linux:: See your distro docs (many Linux distributions, like Ubuntu, come with Python 3.5+ preinstalled)
 
-. Install pip by downloading this script: https://bootstrap.pypa.io/get-pip.py[].
-
-. Run this script using Python 3:
-+
-[source,bash]
-----
-$ python3 get-pip.py
-----
-
 . Install Git. The commands for downloading and installing it are at https://git-scm.com/downloads[].
 
 . Download the source code for this book:


### PR DESCRIPTION
Setup instructions include step for installing `pip`.  This is not necessary, since the earlier step installs `python` using a binary installer, which has included `pip` since version 3.4.

From https://docs.python.org/3/installing/index.html:

> pip is the preferred installer program. Starting with Python 3.4, it is included by default with the Python binary installers.

Also, from personal experience, I know installing `pip` is completely unnecessary nowadays; I'd never even heard of the `get-pip` script despite multiple python installations for myself and others (of course, over only the last 5 years or so...).
