### PR TITLE
Ch 6 - Script() initializes with list

### DIFF
--- a/code-ch06/Chapter6.ipynb
+++ b/code-ch06/Chapter6.ipynb
@@ -140,7 +140,7 @@
     "\n",
     "from script import Script\n",
     "\n",
-    "script_pubkey = Script(0x6e, 0x87, 0x91, 0x91, 0x69, 0xa7, 0x7c, 0xa7, 0x87)\n",
+    "script_pubkey = Script([0x6e, 0x87, 0x91, 0x91, 0x69, 0xa7, 0x7c, 0xa7, 0x87])\n",
     "script_sig = Script([])  # FILL THIS IN\n",
     "combined_script = script_sig + script_pubkey\n",
     "print(combined_script.evaluate(0))"


### PR DESCRIPTION
A `Script()` object is initialized with either no argument or a `list` argument (otherwise I get a `TypeError`).