### PR TITLE
`Tx.sign_input` should allow uncompressed pub key

### DIFF
--- a/code-ch07/answers.py
+++ b/code-ch07/answers.py
@@ -171,11 +171,11 @@ Write the `sign_input` method for the `Tx` class.
 
 
 # tag::answer3[]
-def sign_input(self, input_index, private_key):
+def sign_input(self, input_index, private_key, compressed=True):
     z = self.sig_hash(input_index)
     der = private_key.sign(z).der()
     sig = der + SIGHASH_ALL.to_bytes(1, 'big')
-    sec = private_key.point.sec()
+    sec = private_key.point.sec(compressed)
     self.tx_ins[input_index].script_sig = Script([sig, sec])
     return self.verify_input(input_index)
 # end::answer3[]

--- a/code-ch07/tx.py
+++ b/code-ch07/tx.py
@@ -196,7 +196,7 @@ class Tx:
         return True
     # end::source2[]
 
-    def sign_input(self, input_index, private_key):
+    def sign_input(self, input_index, private_key, compressed=True):
         # get the signature hash (z)
         # get der signature of z from private key
         # append the SIGHASH_ALL to der (use SIGHASH_ALL.to_bytes(1, 'big'))


### PR DESCRIPTION
Without the functionality of creating a ScriptSig with an uncompressed SEC for the public key, it is not possible to spend bitcoin sent to an address created from an uncompressed SEC.

I created an uncompressed address in Chapter 4 and had a testnet faucet send to it but then struggled to complete exercise 4 in Chapter 7, due to the `Tx.sign_input` method not having a "compressed" arg.