### PR TITLE
fix typos in p2sh code example

### DIFF
--- a/ch08.asciidoc
+++ b/ch08.asciidoc
@@ -298,9 +298,9 @@ class Script:
 ...
     def evaluate(self, z):
 ...
-        while len(commands) > 0:
-            command = commands.pop(0)
-            if type(command) == int:
+        while len(cmds) > 0:
+            cmd = cmds.pop(0)
+            if type(cmd) == int:
 ...
 include::code-ch08/script.py[tag=source1]
 ----


### PR DESCRIPTION
To match the inserted code, `commands` in the preceding context code should be replaced by `cmds`. 