### PR TITLE
fix names/links for exercises 2 & 3

### DIFF
--- a/code-ch08/Chapter8.ipynb
+++ b/code-ch08/Chapter8.ipynb
@@ -60,7 +60,7 @@
     "\n",
     "Write `h160_to_p2pkh_address` that converts a 20-byte hash160 into a p2pkh address.\n",
     "\n",
-    "#### Make [this test](/edit/code-ch08/helper.HelperTest.py) pass: `helper.HelperTest.py::test_p2pkh_address`"
+    "#### Make [this test](/edit/code-ch08/helper.py) pass: `helper.HelperTest.py::test_p2pkh_address`"
    ]
   },
   {
@@ -71,8 +71,8 @@
    "source": [
     "# Exercise 2\n",
     "\n",
-    "reload(helper.HelperTest)\n",
-    "run(helper.HelperTest.(\"test_p2pkh_address\"))"
+    "reload(helper)\n",
+    "run(helper.HelperTest(\"test_p2pkh_address\"))"
    ]
   },
   {
@@ -83,7 +83,7 @@
     "\n",
     "Write `h160_to_p2sh_address` that converts a 20-byte hash160 into a p2sh address.\n",
     "\n",
-    "#### Make [this test](/edit/code-ch08/helper.HelperTest.py) pass: `helper.HelperTest.py::test_p2sh_address`"
+    "#### Make [this test](/edit/code-ch08/helper.py) pass: `helper.HelperTest.py::test_p2sh_address`"
    ]
   },
   {
@@ -94,8 +94,8 @@
    "source": [
     "# Exercise 3\n",
     "\n",
-    "reload(helper.HelperTest)\n",
-    "run(helper.HelperTest.(\"test_p2sh_address\"))"
+    "reload(helper)\n",
+    "run(helper.HelperTest(\"test_p2sh_address\"))"
    ]
   },
   {


### PR DESCRIPTION
Several typos:
- links to helper module are wrong
- reload command takes in modules, not the test class
- extraneous dots in the test running command