### PR TITLE
ch07 code fixes

### DIFF
--- a/code-ch07/Chapter7.ipynb
+++ b/code-ch07/Chapter7.ipynb
@@ -27,7 +27,7 @@
     "from io import BytesIO\n",
     "raw_tx = ('0100000001813f79011acb80925dfe69b3def355fe914bd1d96a3f5f71bf8303c6a989c7d1000000006b483045022100ed81ff192e75a3fd2304004dcadb746fa5e24c5031ccfcf21320b0277457c98f02207a986d955c6e0cb35d446a89d3f56100f4d7f67801c31967743a9c8e10615bed01210349fc4e631e3624a545de3f89f5d8684c7b8138bd94bdd531d2e213bf016b278afeffffff02a135ef01000000001976a914bc3b654dca7e56b04dca18f2566cdaf02e8d9ada88ac99c39800000000001976a9141c4bc762dd5423e332166702cb75f40df79fea1288ac19430600')\n",
     "stream = BytesIO(bytes.fromhex(raw_tx))\n",
-    "transaction = Tx.parse(stream)\n",
+    "transaction = Tx.parse(stream, testnet=True)\n",
     "print(transaction.fee() >= 0)"
    ]
   },

--- a/code-ch07/Chapter7.ipynb
+++ b/code-ch07/Chapter7.ipynb
@@ -153,14 +153,14 @@
    "source": [
     "from ecc import PrivateKey\n",
     "from helper import SIGHASH_ALL\n",
-    "z = transaction.sig_hash(0)\n",
+    "z = tx_obj.sig_hash(0)\n",
     "private_key = PrivateKey(secret=8675309)\n",
     "der = private_key.sign(z).der()\n",
     "sig = der + SIGHASH_ALL.to_bytes(1, 'big')\n",
     "sec = private_key.point.sec()\n",
     "script_sig = Script([sig, sec])\n",
-    "transaction.tx_ins[0].script_sig = script_sig \n",
-    "print(transaction.serialize().hex())"
+    "tx_obj.tx_ins[0].script_sig = script_sig \n",
+    "print(tx_obj.serialize().hex())"
    ]
   },
   {
@@ -274,7 +274,7 @@
     "from tx import TxIn, TxOut, Tx\n",
     "\n",
     "# Create 2 TxIns, 1 from the Exercise 4 and 1 from a testnet faucet\n",
-    "# Creat 1 TxOut to the address above\n",
+    "# Create 1 TxOut to the address above\n",
     "target_address = 'mwJn1YPMq7y5F8J3LkC5Hxg9PHyZ5K4cFv'\n",
     "\n",
     "# get the private key from the exercise in Chapter 4\n",


### PR DESCRIPTION
This branch contains a few minor fixes to the chapter 7 code:
* a fix for the second cell: it needs to parse on testnet instead of mainnet (a 404/crash is triggered when trying to parse on mainnet)
* a code var rename (`transaction` => `tx_obj`) to fix cell execution (`transaction` is not declared anywhere)
* a simple typo fix (creat => create)