### PR TITLE
conform to gh flavored md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#[Programming Bitcoin](https://learning.oreilly.com/library/view/programming-bitcoin/9781492031482/)
+# [Programming Bitcoin](https://learning.oreilly.com/library/view/programming-bitcoin/9781492031482/)
 
-###BY[ JIMMY SONG](https://github.com/jimmysong)
+### BY[ JIMMY SONG](https://github.com/jimmysong)
 
-#####[O'Reilly Media, Inc.March 2019](https://learning.oreilly.com/library/publisher/oreilly-media-inc/)
+##### [O'Reilly Media, Inc.March 2019](https://learning.oreilly.com/library/publisher/oreilly-media-inc/)
 
 # LICENSE
 
@@ -11,12 +11,12 @@ Repository for the book to be published by O'Reilly.
 This book will be licensed under [CC-BY-NC-ND](https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode) once the book is published.
 
 
-##Setting Up
+## Setting Up
 
 
 To get the most out of this book, you’ll want to create an environment where you can run the example code and do the exercises. Here are the steps required to set everything up:
 
-###1. Install Python 3.5 or higher on your machine:
+### 1. Install Python 3.5 or higher on your machine:
 
 Windows:		
 [https://www.python.org/ftp/python/3.6.2/python-3.6.2-amd64.exe
@@ -27,26 +27,26 @@ macOS:
 [https://www.python.org/ftp/python/3.6.2/python-3.6.2-macosx10.6.pkg](https://www.python.org/ftp/python/3.6.2/python-3.6.2-macosx10.6.pkg)
 
 Linux		
-#####See your distro docs (many Linux distributions, like Ubuntu, come with Python 3.5+ preinstalled)
+##### See your distro docs (many Linux distributions, like Ubuntu, come with Python 3.5+ preinstalled)
 
-###2. Install pip by downloading this script: [https://bootstrap.pypa.io/get-pip.py](https://bootstrap.pypa.io/get-pip.py).
+### 2. Install pip by downloading this script: [https://bootstrap.pypa.io/get-pip.py](https://bootstrap.pypa.io/get-pip.py).
 
-###3. Run this script using Python 3:
+### 3. Run this script using Python 3:
 
 `$ python3 get-pip.py`		
 
-###4. Install Git. The commands for downloading and installing it are at [https://git-scm.com/downloads](https://git-scm.com/downloads).
+### 4. Install Git. The commands for downloading and installing it are at [https://git-scm.com/downloads](https://git-scm.com/downloads).
 
-###5. Download the source code for this book:
+### 5. Download the source code for this book:
 
 `$ git clone https://github.com/jimmysong/programmingbitcoin`		
 `$ cd programmingbitcoin`
 		
-###6. Install virtualenv:
+### 6. Install virtualenv:
 
 `$ pip install virtualenv`
 
-###7. Install the requirements:
+### 7. Install the requirements:
 
 Linux/macOS
 
@@ -60,7 +60,7 @@ Windows
 `C:\PathToYourPythonInstallation\Python.exe .venv`		
 `C:\programmingbitcoin> .venv\Scripts\activate.bat`		
 `C:\programmingbitcoin> pip install -r requirements.txt`		
-###8. Run Jupyter Notebook:
+### 8. Run Jupyter Notebook:
 
 `(.venv) $ jupyter notebook`
 `[I 11:13:23.061 NotebookApp] Serving notebooks from local directory:


### PR DESCRIPTION
This is related to @kanzure 's patch https://github.com/kanzure/programmingbitcoin/tree/patch-1
As a rule I am only writing markdown that conforms to @github 's flavor even for other content.
@github would be wise to create a cross platform markdown editor. They have enough reach now to set the standard.
Serious apology for the blunder.