### PR TITLE
Update raw_serialize method

### DIFF
--- a/code-ch05/script.py
+++ b/code-ch05/script.py
@@ -95,7 +95,7 @@ class Script:
                 # get the length in bytes
                 length = len(cmd)
                 # for large lengths, we have to use a pushdata opcode
-                if length < 75:
+                if length <= 75:
                     # turn the length into a single byte integer
                     result += int_to_little_endian(length, 1)
                 elif length > 75 and length < 0x100:


### PR DESCRIPTION
In the first if statement when cmd is not an opcode, the comparison operator should be <= because if length is 75 it should get into the if statement.