### PR TITLE
Fix op_2rot function in op.py

### DIFF
--- a/code-ch13/op.py
+++ b/code-ch13/op.py
@@ -285,7 +285,7 @@ def op_2over(stack):
 def op_2rot(stack):
     if len(stack) < 6:
         return False
-    stack.extend(stack[-6:-4])
+    stack[-6:] = stack[-4:] + stack[-6:-4]
     return True
 
 


### PR DESCRIPTION
Function should move 5th and 6th items back in the stack to the top of the stack, not copy them. Stack should remain the same size.