### PR TITLE
<redeem_script> length should be encoded to varint.

### DIFF
--- a/code-ch13/tx.py
+++ b/code-ch13/tx.py
@@ -310,7 +310,7 @@ class Tx:
             # the last cmd has to be the RedeemScript to trigger
             cmd = tx_in.script_sig.cmds[-1]
             # parse the RedeemScript
-            raw_redeem = int_to_little_endian(len(cmd), 1) + cmd
+            raw_redeem = encode_varint(len(cmd)) + cmd
             redeem_script = Script.parse(BytesIO(raw_redeem))
             # the RedeemScript might be p2wpkh or p2wsh
             if redeem_script.is_p2wpkh_script_pubkey():


### PR DESCRIPTION
<redeem_script> element can be 520bytes.
so, the length should be encoded to varint but it is encoded to 1byte int.
and it decodes 1byte int to varint in the parse function below.

script.py#L78
def parse(cls, s):
    # get the length of the entire field
    length = read_varint(s)