### PR TITLE
[CH8]fix exercise2 and 3

### DIFF
--- a/code-ch08/Chapter8.ipynb
+++ b/code-ch08/Chapter8.ipynb
@@ -71,8 +71,8 @@
    "source": [
     "# Exercise 2\n",
     "\n",
-    "reload(helper.HelperTest)\n",
-    "run(helper.HelperTest.(\"test_p2pkh_address\"))"
+    "reload(helper)\n",
+    "run(helper.HelperTest(\"test_p2pkh_address\"))"
    ]
   },
   {
@@ -94,8 +94,8 @@
    "source": [
     "# Exercise 3\n",
     "\n",
-    "reload(helper.HelperTest)\n",
-    "run(helper.HelperTest.(\"test_p2sh_address\"))"
+    "reload(helper)\n",
+    "run(helper.HelperTest(\"test_p2sh_address\"))"
    ]
   },
   {


### PR DESCRIPTION
Because the exercise2 and 3 does not work properly on python 3.8.5. 