### PR TITLE
[Chapter9]fix test_target

### DIFF
--- a/code-ch09/block.py
+++ b/code-ch09/block.py
@@ -150,7 +150,6 @@ class BlockTest(TestCase):
         stream = BytesIO(block_raw)
         block = Block.parse(stream)
         self.assertEqual(block.target(), 0x13ce9000000000000000000000000000000000000000000)
-        self.assertEqual(int(block.difficulty()), 888171856257)
 
     def test_difficulty(self):
         block_raw = bytes.fromhex('020000208ec39428b17323fa0ddec8e887b4a7c53b8c0a0a220cfd0000000000000000005b0750fce0a889502d40508d39576821155e9c9e3f5c3157f961db38fd8b25be1e77a759e93c0118a4ffd71d')


### PR DESCRIPTION
`block.difficulty()` should not tested by test_target.