### PR TITLE
Fixed op_2rot implementation

### DIFF
--- a/code-ch06/op.py
+++ b/code-ch06/op.py
@@ -278,7 +278,7 @@ def op_2over(stack):
 def op_2rot(stack):
     if len(stack) < 6:
         return False
-    stack = stack[:-6] + stack[-4:] + stack[-6:-4]
+    stack[:] = stack[:-6] + stack[-4:] + stack[-6:-4]
     return True
 
 

--- a/code-ch06/op.py
+++ b/code-ch06/op.py
@@ -278,7 +278,7 @@ def op_2over(stack):
 def op_2rot(stack):
     if len(stack) < 6:
         return False
-    stack.extend(stack[-6:-4])
+    stack = stack[:-6] + stack[-4:] + stack[-6:-4]
     return True
 
 


### PR DESCRIPTION
According to https://en.bitcoin.it/wiki/Script#Stack the OP_2ROT operation should move the 5th and 6th last elements to the top of the stack, not duplicate them.

Fixes #139.