### PR TITLE
Difficulty Adjustment Ch 9, first and last swapped

### DIFF
--- a/code-ch09/Chapter9.ipynb
+++ b/code-ch09/Chapter9.ipynb
@@ -383,8 +383,8 @@
    "source": [
     "from block import Block\n",
     "from helper import TWO_WEEKS\n",
-    "last_block = Block.parse(BytesIO(bytes.fromhex('00000020fdf740b0e49cf75bb3d5168fb3586f7613dcc5cd89675b0100000000000000002e37b144c0baced07eb7e7b64da916cd3121f2427005551aeb0ec6a6402ac7d7f0e4235954d801187f5da9f5')))\n",
-    "first_block = Block.parse(BytesIO(bytes.fromhex('000000201ecd89664fd205a37566e694269ed76e425803003628ab010000000000000000bfcade29d080d9aae8fd461254b041805ae442749f2a40100440fc0e3d5868e55019345954d80118a1721b2e')))\n",
+    "first_block = Block.parse(BytesIO(bytes.fromhex('00000020fdf740b0e49cf75bb3d5168fb3586f7613dcc5cd89675b0100000000000000002e37b144c0baced07eb7e7b64da916cd3121f2427005551aeb0ec6a6402ac7d7f0e4235954d801187f5da9f5')))\n",
+    "last_block = Block.parse(BytesIO(bytes.fromhex('000000201ecd89664fd205a37566e694269ed76e425803003628ab010000000000000000bfcade29d080d9aae8fd461254b041805ae442749f2a40100440fc0e3d5868e55019345954d80118a1721b2e')))\n",
     "time_differential = last_block.timestamp - first_block.timestamp\n",
     "if time_differential > TWO_WEEKS * 4:\n",
     "    time_differential = TWO_WEEKS * 4\n",


### PR DESCRIPTION
In the example showing how to calculate the difficulty adjustment the block set as `first_block` was block `469727` and the block set as the`last_block` was block `467712`. I believe these are backward.