### PR TITLE
Chatper5.ipynb: Exercise 6 cell needs `import tx`

### DIFF
--- a/code-ch05/Chapter5.ipynb
+++ b/code-ch05/Chapter5.ipynb
@@ -193,6 +193,7 @@
    "source": [
     "# Exercise 6\n",
     "\n",
+    "import tx\n",
     "reload(tx)\n",
     "run(tx.TxTest(\"test_fee\"))"
    ]


### PR DESCRIPTION
Without re-importing `tx` in the Exercise 6 cell, it throws the following error `TypeError: reload() argument must be a module`