### PR TITLE
Ch 11 Add merkleblock to import loading cell

### DIFF
--- a/code-ch11/Chapter11.ipynb
+++ b/code-ch11/Chapter11.ipynb
@@ -16,7 +16,8 @@
     "import helper\n",
     "import network\n",
     "import script\n",
-    "import tx"
+    "import tx\n",
+    "import merkleblock"
    ]
   },
   {


### PR DESCRIPTION
Exercises 6 and 7 of Ch 11 fail to run due to merkleblock not being defined. Importing it in the top cell along with the other files fixes this.

See issue https://github.com/jimmysong/programmingbitcoin/issues/254