### PR TITLE
Fix broken link in Chapter7.ipynb

### DIFF
--- a/code-ch07/Chapter7.ipynb
+++ b/code-ch07/Chapter7.ipynb
@@ -207,7 +207,7 @@
     "\n",
     "Create a testnet transaction that sends 60% of a single UTXO to `mwJn1YPMq7y5F8J3LkC5Hxg9PHyZ5K4cFv`. The remaining amount minus fees should go back to your own change address. This should be a 1 input, 2 output transaction.\n",
     "\n",
-    "You can broadcast the transaction at https://testnet.blockchain.info/pushtx"
+    "You can broadcast the transaction at https://blockstream.info/testnet/tx/push"
    ]
   },
   {
@@ -246,7 +246,7 @@
     "\n",
     "# sign the one input in the transaction object using the private key\n",
     "# print the transaction's serialization in hex\n",
-    "# broadcast at http://testnet.blockchain.info/pushtx"
+    "# broadcast at https://blockstream.info/testnet/tx/push"
    ]
   },
   {
@@ -257,7 +257,7 @@
     "\n",
     "Advanced: get some more testnet coins from a testnet faucet and create a 2 input, 1 output transaction. 1 input should be from the faucet, the other should be from the previous exercise, the output can be your own address.\n",
     "\n",
-    "You can broadcast the transaction at https://testnet.blockchain.info/pushtx"
+    "You can broadcast the transaction at https://blockstream.info/testnet/tx/push"
    ]
   },
   {
@@ -295,7 +295,7 @@
     "# sign the first input using the private key\n",
     "# sign the second input using the private key \n",
     "# print the transaction's serialization in hex\n",
-    "# broadcast at http://testnet.blockchain.info/pushtx"
+    "# broadcast at https://blockstream.info/testnet/tx/push"
    ]
   }
  ],


### PR DESCRIPTION
Replacing all instances of the `http://testnet.blockchain.info/pushtx` with a functioning link pointing to `https://blockstream.info/testnet/tx/push`